### PR TITLE
Add permanent kill switch and redirect stderr and stdout for up check

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,4 +36,4 @@ jobs:
           push: true
           tags: |
             walt3rl/proton-privoxy:latest
-            walt3rl/proton-privoxy:0.4.2
+            walt3rl/proton-privoxy:0.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,15 @@ ENV PVPN_USERNAME= \
     PVPN_PROTOCOL=udp \
     PVPN_CMD_ARGS="connect --fastest" \
     PVPN_DEBUG= \
+    PVPN_KILL=1\
     HOST_NETWORK= \
     DNS_SERVERS_OVERRIDE=
 
 COPY app /app
 COPY pvpn-cli /root/.pvpn-cli
 
-RUN apk --update add coreutils openvpn privoxy procps python3 runit \
+RUN apk --update add coreutils openvpn privoxy procps python3 runit iptables nftables \
     && python3 -m ensurepip \
-    && pip3 install protonvpn-cli
+    && pip3 install protonvpn-cli && adduser -D -H -S --shell /bin/sh privoxyu
 
 CMD ["runsvdir", "/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 LABEL maintainer="Walter Leibbrandt"
-LABEL version="0.4.2"
+LABEL version="0.5.0"
 # XXX Copy version to Docker image tag in .github/workflows/docker.yml when changing!
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ be routed over the same VPN connection.
 Why did I choose Privoxy? Mostly because it's the simplest HTTP proxy to
 configure, that I've used before.
 
-### Built-in Killswitch
+### Built-in killswitch
 On startup, permanent killswitch ensures all connections use the protonvpn interface.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ be routed over the same VPN connection.
 Why did I choose Privoxy? Mostly because it's the simplest HTTP proxy to
 configure, that I've used before.
 
+### ~[Anti-feature] ProtonVPN's DNS leak protection doesn't work~
+
+**UPDATE:** This is no longer an issue, because Docker now allows
+`/etc/resolv.conf` to be updated while a container is running. It's recreated
+by Docker on container restart, but that doesn't matter, since ProtonVPN (and
+`DNS_SERVERS_OVERRIDE`) will modify it during startup.
+
+~Docker prevents containers from changing the servers used for DNS lookups, after startup. This prevents ProtonVPN from using its own leak protecting DNS server. In fact, at the moment it causes a non-fatal error in `protonvpn`.~
+
+~Ensure that you're using privacy respecting DNS servers on your Docker host, or manually specify secure servers for the container via [`--dns` options](https://docs.docker.com/config/containers/container-networking/#dns-services).~
+
 ### Built-in killswitch
 On startup, permanent killswitch ensures all connections use the protonvpn interface.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Default: _empty_ (debug logging disabled)
 
 ### `PVPN_KILL`
 
-Set to `0` to disable permanent kill switch.
+Set to `0` to disable permanent kill switch. May have unexpected outcome when used with protonvpn killswitch.
 
 Default: `1` (killswitch enabled)
 

--- a/README.md
+++ b/README.md
@@ -78,17 +78,8 @@ be routed over the same VPN connection.
 Why did I choose Privoxy? Mostly because it's the simplest HTTP proxy to
 configure, that I've used before.
 
-### ~[Anti-feature] ProtonVPN's DNS leak protection doesn't work~
-
-**UPDATE:** This is no longer an issue, because Docker now allows
-`/etc/resolv.conf` to be updated while a container is running. It's recreated
-by Docker on container restart, but that doesn't matter, since ProtonVPN (and
-`DNS_SERVERS_OVERRIDE`) will modify it during startup.
-
-~Docker prevents containers from changing the servers used for DNS lookups, after startup. This prevents ProtonVPN from using its own leak protecting DNS server. In fact, at the moment it causes a non-fatal error in `protonvpn`.~
-
-~Ensure that you're using privacy respecting DNS servers on your Docker host, or manually specify secure servers for the container via [`--dns` options](https://docs.docker.com/config/containers/container-networking/#dns-services).~
-
+### Built-in Killswitch
+On startup, permanent killswitch ensures all connections use the protonvpn interface.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Set to `1` to log debugging details from `protonvpn` to the container's stdout.
 
 Default: _empty_ (debug logging disabled)
 
+### `PVPN_KILL`
+
+Set to `0` to disable permanent kill switch.
+
+Default: `1` (debug logging disabled)
+
 ### `HOST_NETWORK`
 
 If you want to expose your proxy server to your local network, you need to
@@ -158,3 +164,4 @@ ProtonVPN. For example, to use Quad9 DNS servers, set
 `DNS_SERVERS_OVERRIDE=9.9.9.9,149.112.112.112`.
 
 Default: _empty_ (ProtonVPN's DNS server is used)
+

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Default: _empty_ (debug logging disabled)
 
 Set to `0` to disable permanent kill switch.
 
-Default: `1` (debug logging disabled)
+Default: `1` (killswitch enabled)
 
 ### `HOST_NETWORK`
 

--- a/app/proton-privoxy/config
+++ b/app/proton-privoxy/config
@@ -1,5 +1,6 @@
 confdir /app/proton-privoxy
 logdir /var/log/privoxy
+logfile
 listen-address  0.0.0.0:8080
 
 #debug   1    # show each GET/POST/CONNECT request

--- a/app/proton-privoxy/run
+++ b/app/proton-privoxy/run
@@ -64,7 +64,7 @@ if [ -n "$HOST_NETWORK" ]; then
 fi
 
 # Set Killswitch
-if [ $PVPN_KILL -eq 1 ]
+if [ $PVPN_KILL -eq 1 ]; then
 nft -f $PVDIR/killswitch.conf
 fi
 

--- a/app/proton-privoxy/run
+++ b/app/proton-privoxy/run
@@ -65,7 +65,7 @@ fi
 
 # Set Killswitch
 if [ $PVPN_KILL -eq 1 ]; then
-nft -f $PVDIR/killswitch.conf
+	nft -f $PVDIR/killswitch.conf
 fi
 
 # Start Privoxy

--- a/app/proton-privoxy/run
+++ b/app/proton-privoxy/run
@@ -45,7 +45,7 @@ protonvpn refresh
 # shellcheck disable=SC2086
 protonvpn $PVPN_CMD_ARGS
 
-if ! ip link show proton0 > /dev/null; then
+if ! ip link show proton0 &> /dev/null; then
 	echo "Failed to bring up VPN :("
 	exit 1
 fi
@@ -63,6 +63,11 @@ if [ -n "$HOST_NETWORK" ]; then
 	ip route add "$HOST_NETWORK" via "$gw"
 fi
 
+# Set Killswitch
+if [ $PVPN_KILL -eq 1 ]
+nft -f $PVDIR/killswitch.conf
+fi
+
 # Start Privoxy
 ln -s /etc/privoxy/templates /app/proton-privoxy/
-exec privoxy --no-daemon
+exec su privoxyu -c 'privoxy --no-daemon;'

--- a/app/proton-privoxy/run
+++ b/app/proton-privoxy/run
@@ -70,4 +70,4 @@ fi
 
 # Start Privoxy
 ln -s /etc/privoxy/templates /app/proton-privoxy/
-exec su privoxyu -c 'privoxy --no-daemon;'
+exec su privoxyu -c 'privoxy --no-daemon'

--- a/pvpn-cli/killswitch.conf
+++ b/pvpn-cli/killswitch.conf
@@ -1,4 +1,4 @@
-#!/bin/env net -f
+#!/bin/env nft -f
 
 table inet filter {
 

--- a/pvpn-cli/killswitch.conf
+++ b/pvpn-cli/killswitch.conf
@@ -1,0 +1,33 @@
+#!/bin/env net -f
+
+table inet filter {
+
+    chain input {
+        type filter hook input priority 0; policy drop;
+        # Allow loopback
+        iif lo accept
+
+        # Allow established and related traffic
+        ct state new,established,related accept
+        
+        # Drop everything else
+        drop
+    }
+
+   chain output {
+        type filter hook output priority 0; policy drop;
+        # Allow loopback
+        oif lo accept
+        # Allow protonvpn
+        oif eth0 skuid root accept
+        # Allow established and related traffic
+        ct state established,related accept
+
+        # Allow outgoing traffic on the proton0 interface (IPv4)
+        oifname "proton0" accept
+
+        # Drop everything else
+        drop
+}
+
+}

--- a/pvpn-cli/killswitch.conf
+++ b/pvpn-cli/killswitch.conf
@@ -23,7 +23,7 @@ table inet filter {
         # Allow established and related traffic
         ct state established,related accept
 
-        # Allow outgoing traffic on the proton0 interface (IPv4)
+        # Allow outgoing traffic on the proton0 interface
         oifname "proton0" accept
 
         # Drop everything else

--- a/pvpn-cli/killswitch.conf
+++ b/pvpn-cli/killswitch.conf
@@ -7,7 +7,7 @@ table inet filter {
         # Allow loopback
         iif lo accept
 
-        # Allow established and related traffic
+        # Allow new, established, and related traffic
         ct state new,established,related accept
         
         # Drop everything else

--- a/test/docker_secrets_test/docker-compose.yml
+++ b/test/docker_secrets_test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   proton-privoxy:
-    image: walt3rl/proton-privoxy:0.4.2-dev
+    image: walt3rl/proton-privoxy:0.5.0-dev
     container_name: proton-privoxy
     environment:
       - PVPN_USERNAME_FILE=/test/creds/username

--- a/test/docker_secrets_test/test.sh
+++ b/test/docker_secrets_test/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#docker build -t walt3rl/proton-privoxy:0.4.2-dev ../..
+#docker build -t walt3rl/proton-privoxy:0.5.0-dev ../..
 docker-compose up -d
 pvpnpass=$(docker-compose exec proton-privoxy cat /root/.pvpn-cli/pvpnpass)
 docker-compose down


### PR DESCRIPTION
[linux-cli-community](https://github.com/Rafficer/linux-cli-community) may be unmantained. Resolves #5 by adding package `iptables`.


Adds experimental kill-switch separate from the cli to container. Permanent kill switch is set to default. The killswitch is ip-agnostic relying on processes and interfaces(eth0 and proton0) and supports ipv6 from using nftables.

 Below was the initial nfttable configure file but took space using sets even when size of 65535 is sufficient above [128](http://www.privoxy.org/3.0.21/user-manual/config.html), it would hinder configurability. Privoxy also [recommends](https://www.privoxy.org/user-manual/installation.html) not to run as root. Finally manually enabling the cli killswitch may cause unexpected results.
Not tested in swarm mode. 
```
#!/bin/env net -f
table inet filter {
  set eth0_clients4 {                                                 
        type ipv4_addr  
  size 65535                                              
        flags timeout         
gc-interval 1d                           
    }           

set eth0_clients6 {                                                 
        type ipv6_addr    
  size 65535                                            
        flags timeout          
gc-interval 1d                          
    }           

    chain input {
        type filter hook input priority 0; policy drop;
	iif lo accept
        # Add IP addresses to the eth0_clients set when clients connect
        add @eth0_clients4 {ip saddr} 
        add @eth0_clients6 {ip6 saddr} 

        # Allow incoming traffic from eth0 to Privoxy (IPv4)
        iifname "eth0" ip saddr @eth0_clients4 accept

        # Allow incoming traffic from eth0 to Privoxy (IPv6)
        iifname "eth0" ip6 saddr @eth0_clients6 accept

        # Allow established and related traffic
        ct state established,related accept

        # Drop everything else
        drop
    }

   chain output {
    type filter hook output priority 0; policy drop;
    
	oif lo accept
	oif eth0 skuid root accept

          # Allow established and related traffic
	ct state established,related accept
        
# Drop eth0 loopbacks
	ip saddr @eth0_clients4 drop
	ip6 saddr @eth0_clients6 drop
    # Remove IP addresses from the eth0_clients set when traffic goes out on proton0 (IPv4)
     oifname proton0 ip daddr @eth0_clients4 
	delete @eth0_clients4  {ip daddr }

    # Remove IP addresses from the eth0_clients set when traffic goes out on proton0 (IPv6)
     oifname proton0 ip6 daddr @eth0_clients6 
	delete @eth0_clients6  {ip6 daddr }

    # Allow outgoing traffic on the proton0 interface 
    oifname "proton0" accept

    # Drop everything else
    drop
}

}

```



Minor change was from seeing #36 and preventing some redundant output.