### PR TITLE
Add `ip6tables` Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PVPN_USERNAME= \
 COPY app /app
 COPY pvpn-cli /root/.pvpn-cli
 
-RUN apk --update add coreutils openvpn privoxy procps python3 runit git \
+RUN apk --update add coreutils openvpn ip6tables privoxy procps python3 runit git \
     && python3 -m ensurepip \
     && pip3 install git+https://github.com/Rafficer/linux-cli-community.git@v$PVPN_CLI_VER
 


### PR DESCRIPTION
As mentioned in issue #63, the ProtonVPN community client tries to use the `ip6tables-save` command and fails doing so.

Changes made in this PR add the `ip6tables`-package which provides said command.
As far as I can tell, this resolves the issue.

Thus, merging this PR will fix #63.